### PR TITLE
Adding TrackSource: emitting photons along the track

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
     + [Tree structure of expressions](#tree-structure-of-expressions)
     + [Inspecting](#inspecting)
     + [Modifying](#modifying)
-  * [Inspecting trajectories](#inspecting-trajectories)
+- [Inspecting trajectories](#inspecting-trajectories)
     + [3D viewer](#3d-viewer)
 - [License](#license)
 
@@ -59,7 +59,7 @@ pip install "git+https://https://github.com/RTESolution/rte.git[gui, test]"
 
 In order to do the calculation, the user needs to define the following objects:
 
-* `rte.Source` - describing the emission of the photons - their initial time, position and direction
+* `rte.Source` - describing the emission of the photons - their initial time, position and direction. See [Sources section](#sources) for more information.
 * `rte.Target` - describing the detection of the photons - their final time and position
 * `rte.Medium` - contains constants of the uniform medium, in which the photon will be propagating
 * `rte.Process` - main object which performs the calculation of the probability of a photon, emitted by the `Source` to reach the `Target` after scattering `Nsteps` times.
@@ -67,7 +67,6 @@ In order to do the calculation, the user needs to define the following objects:
 In other words, the `Source` and `Target` define the integration spaces of the initial and final state of the photon trajectory, while the `Process` defines also the intermediate steps.
 
 Here is a full example script of such calculation:
-
 ```python
 import rte #main package module with Target, Source and Process classes
 import vegas_params as vp #definition of the integration spaces
@@ -95,6 +94,29 @@ print(result)
 The position `R`, time `T` and direction `s` arguments in `Source` and `Target` can either be fixed, or distributed (in which case the final calculation will integrate over it). 
 See the [How to define parameter expressions](#how-to-define-parameter-expressions) section to see the examples.
 
+
+### Sources
+Currently we provide two types of sources, all of them can be used for constructing `rte.Process` objects:
+#### Basic source
+`rte.sources.Source`. position, time and direction are sampled ___independently___ of each other.
+Initilaized as in the example above:
+```python
+src = rte.Source(R = vp.Vector([0,0,0]), #fixed point
+                 T = 0, #photons emitted at fixed time 
+                 s = vp.Direction() #uniform direction vector
+                )
+```
+#### `rte.sources.TrackSource`:  creation of photons along a given track.
+It samples track position, direction, speed, time and photon direction relative to track. And in the output it provides the photon starting points, similartly to the basic source.
+```python
+src = rte.source.TrackSource(
+    T = vp.Uniform([0,1e-8]),
+    track_pos = Vector([0,0,0]), #starting point 
+    track_dir = vp.Direction(0.5,0), #45 degrees between X and Z axes
+    track_speed = 3e8, #m/s
+    photon_dir = Direction(cos_theta=0.9)#photon emission angles
+)
+```
 # How to define parameter expressions
 RTE uses [vegas_params](https://github.com/RTESolution/vegas_params) for the definition of the integration space:
 ```python
@@ -216,16 +238,27 @@ trajectories = p.trajectory #get the results
 Trajectories contain the position `R`, time `T` and direction `s` of each photon trajectory segment.
 
 ### 3D viewer 
-You can plot the trajectories with a 3D viewer. In order to do this, make sure to install this module with the "gui" dependencies:
+This package provides a simple 3D viewer functions to inspect trajectories and photon sources. 
+In order to use it, make sure to install this module with the "gui" dependencies:
 ```shell
 pip install -U "rte[gui]"
 ```
+
 and then you can run the viewer:
 ```python
+from rte.viewer import plot_trajectory
 #get the trajectories from the process
 plot_trajectory(p.trajectory, 
                 p.factor**0.95)
 ```
+
+additionally one can inspect the photon source samples:
+```python
+from rte.viewer import plot_photons
+plot_photons(src.sample(100), #generate 100 photons from source
+             photon_size=1) #show each of the photons as 1m line
+```
+
 # License
 
 *TODO*

--- a/src/process.py
+++ b/src/process.py
@@ -5,20 +5,13 @@ from vegas_params.vector import vector
 from vegas_params.utils import swapaxes, swap_axes
 from vegas_params.utils import mask_arrays, unmask_arrays, save_input
 #from vegas_params import integral
-from scipy.spatial.transform import Rotation
 
 from .sources import Point #dataclass which holds trajectory points
 from .steps import StepsUniform, StepsDistribution
 from .medium import Medium
+from .utils import combine_rotations, align_rotation_to_vector
 
 from loguru import logger
-
-def align_rotation_to_vector(v:vector)->Rotation:
-    v = np.asarray(v).view(vector)
-    n = v/v.mag()
-    theta = np.arccos(n.z)
-    phi = np.arctan2(n.y,n.x)
-    return Rotation.from_euler('yz',np.array([theta,phi]).T.squeeze())
 
 # --- Expressions are defined here
 class Process(vp.Expression):

--- a/src/sources.py
+++ b/src/sources.py
@@ -1,8 +1,9 @@
 import numpy as np
 from vegas_params import expression, Uniform
-from vegas_params.vector import vector,Vector, Scalar, Direction, expression
-
+from vegas_params.vector import vector, Vector, Scalar, Direction
 from dataclasses import dataclass
+
+from .utils import combine_rotations
 
 @dataclass 
 class Point:
@@ -41,19 +42,16 @@ class Target:
 class Source(Target):
     pass
 
-def combine_rotations(dir_base:vp.vector, dir_relative:vector)->vp.vector:
-    rot = align_rotation_to_vector(dir_base)
-    return rot.apply(dir_relative.reshape(-1,3)).view(vector)
+@expression
+class TrackSource:
+    T: Scalar
+    track_pos: Vector = Vector([0,0,0])
+    track_speed: Scalar = 3e8 #m/s
+    track_dir: Direction = Direction(1,0)
+    photon_dir: Direction = Direction(cos_theta=0.9)
 
-@vp.expression
-class SourceTrack:
-    T: vp.Scalar
-    R0: vp.Vector = vp.Vector([0,0,0])
-    track_dir: vp.Direction = vp.Direction(1,0)
-    photon_dir: vp.Direction = vp.Direction(cos_theta=0.9)
-    track_speed: 
-    
-    def __call__(self, T, R0, track_dir, photon_dir):
-        R = R0+track_dir*T
+    @staticmethod
+    def __call__(T, track_pos, track_speed, track_dir, photon_dir):
+        R = track_pos+track_dir*track_speed*T
         s = combine_rotations(track_dir, photon_dir)
         return Point(R,T,s)

--- a/src/sources.py
+++ b/src/sources.py
@@ -40,3 +40,20 @@ class Target:
 
 class Source(Target):
     pass
+
+def combine_rotations(dir_base:vp.vector, dir_relative:vector)->vp.vector:
+    rot = align_rotation_to_vector(dir_base)
+    return rot.apply(dir_relative.reshape(-1,3)).view(vector)
+
+@vp.expression
+class SourceTrack:
+    T: vp.Scalar
+    R0: vp.Vector = vp.Vector([0,0,0])
+    track_dir: vp.Direction = vp.Direction(1,0)
+    photon_dir: vp.Direction = vp.Direction(cos_theta=0.9)
+    track_speed: 
+    
+    def __call__(self, T, R0, track_dir, photon_dir):
+        R = R0+track_dir*T
+        s = combine_rotations(track_dir, photon_dir)
+        return Point(R,T,s)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,15 @@
+import numpy as np
+import vegas_params as vp
+from vegas_params.vector import vector
+from scipy.spatial.transform import Rotation
+
+def combine_rotations(dir_base:vector, dir_relative:vector)->vector:
+    rot = align_rotation_to_vector(dir_base)
+    return rot.apply(dir_relative.reshape(-1,3)).view(vector)
+
+def align_rotation_to_vector(v:vector)->Rotation:
+    v = np.asarray(v).view(vector)
+    n = v/v.mag()
+    theta = np.arccos(n.z)
+    phi = np.arctan2(n.y,n.x)
+    return Rotation.from_euler('yz',np.array([theta,phi]).T.squeeze())

--- a/src/viewer.py
+++ b/src/viewer.py
@@ -34,3 +34,28 @@ def plot_trajectory(points, factor):
                                antialias=False)
         view.addItem(line)
     view.show()
+
+def plot_photons(points, photon_size=1):
+    view = gl.GLViewWidget()
+    #grids
+    #view.addItem(grid:=gl.GLGridItem())
+    #axes
+    view.addItem(zaxis:=gl.GLGridItem())
+    zaxis.setSize(0,0,10)
+    #colormap
+    alpha=0.7
+    width=2
+    factor=1
+    points.T = normalize(points.T, axis=None).squeeze()
+    cm = pg.colormap.get('CET-D8')
+    for pt in points.iter():
+        color = cm.map([1-pt.T]*2, mode='Float')
+        print(color.shape)
+        #color[:,3]=alpha#set the alpha
+        line=gl.GLLinePlotItem(pos=[pt.R, pt.R+pt.s*photon_size], 
+                               color=color,
+                               width=width,
+                               antialias=False)
+        #plot all the photon directions
+        view.addItem(line)
+    view.show()

--- a/src/viewer.py
+++ b/src/viewer.py
@@ -50,7 +50,6 @@ def plot_photons(points, photon_size=1):
     cm = pg.colormap.get('CET-D8')
     for pt in points.iter():
         color = cm.map([1-pt.T]*2, mode='Float')
-        print(color.shape)
         #color[:,3]=alpha#set the alpha
         line=gl.GLLinePlotItem(pos=[pt.R, pt.R+pt.s*photon_size], 
                                color=color,


### PR DESCRIPTION
This PR adds 
1) `rte.sources.TrackSource` which emits photons along the given track direction
2) `rte.utils` module to contain various utility functions (currently rotations)
3) `rte.viewer.plot_photons` function to plot all the (sample) photons, emitted by a given source

Example code:

```python
import vegas_params as vp
from vegas_params.vector import vector
from rte.sources import TrackSource
from rte.viewer import plot_photons

s = TrackSource(track_dir = vp.Direction(0.5,0),T = vp.Uniform([0,1e-8]))

%gui qt #this is needed in jupyter notebooks before using the viewer
plot_photons(s.sample(100), photon_size=1)
```

produces an image:
![image](https://github.com/RTESolution/rte/assets/6203997/a2d7f19b-ccc7-4a53-9979-b36e2f5efa4e)
