### PR TITLE
Accelerate calculation with multiprocessing

### DIFF
--- a/src/process.py
+++ b/src/process.py
@@ -177,9 +177,10 @@ class Process(vp.Expression):
             p.calculate()
             ```
         """
-        for key, value in override.items():
-            if not key.startswith('_'):
-                self[key]=value
+        if override is not None:
+            for key, value in override.items():
+                if not key.startswith('_'):
+                    self[key]=value
         return vp.integral(self)(**self.vegas_kwargs)
 
     def calculate_map(self, override:dict, 

--- a/src/process.py
+++ b/src/process.py
@@ -150,5 +150,6 @@ class Process(vp.Expression):
 
     def calculate_with(self, override:dict, **vegas_kwargs):
         for key, value in override.items():
-            self[key]=value
-        return p.calculate(**vegas_kwargs)
+            if not key.startswith('_'):
+                self[key]=value
+        return self.calculate(**vegas_kwargs)

--- a/src/process.py
+++ b/src/process.py
@@ -131,5 +131,24 @@ class Process(vp.Expression):
         #return ones - they will be multiplied by the factor automatically
         return np.ones(shape=(1,Nsamples))
 
+    def __getitem__(self, key):
+        expr = super()
+        for token in key.split('.'):
+            expr = expr.__getitem__(token)
+        return expr
+    
+    def __setitem__(self, key, value):
+        try:
+            path, key = key.rsplit('.',1)
+            expr = self[path]
+        except ValueError:
+            expr = super()
+        expr.__setitem__(key, value)
+        
     def calculate(self, **vegas_kwargs):
         return vp.integral(self)(**vegas_kwargs)
+
+    def calculate_with(self, override:dict, **vegas_kwargs):
+        for key, value in override.items():
+            self[key]=value
+        return p.calculate(**vegas_kwargs)


### PR DESCRIPTION
Closes #9 

A bunch of minor interface changes:
1. `Process.__getitem__` operator can now accept dot-separated paths. For example 
```python
p['src.T']=vp.Uniform(0,1) #change source time distribution
p['tgt.T']=1 #change the time of the target to fixed value
```

2. `Process.calculate` now has `override` parameter, to run calculation with different  parameters:
```python
p.calculate(override={'tgt.T':1})
#equivalent to this:
p['tgt.T']=1
p.calculate()
```
3. A new method to run parallel calculations `Process.calculate_map`. By default it calculates using multiprocess parallelism (concurrent.futures.ProcessPool).

### Usage example:

Initial setup:

```python
import numpy as np

import rte
import vegas_params as vp
import pylab as plt
from tqdm.auto import tqdm

#initial setup for source and target
src = rte.Source(R=vp.Vector([0,0,0]),
                 T=0,
                 s=vp.Vector([0,0,1]))

tgt = rte.Target(R=vp.Vector([1,0,1]),
                 T=1e-7,
                 s=vp.Vector([0,0,1]))
        
p = rte.Process(src, tgt, medium=rte.medium.water, Nsteps=2, use_uniform_sampling=False)

times = np.geomspace(1e-8,1e-7,51)
```

Run sequentially (without ProcessPoolExecutor) to calculate 51 time points, repeating each calculation 10 times:
```python
%%time
v = p.calculate_map({'src.T':times, '_i':np.arange(10)}, 
                    output='reshape', map_function=map)
#CPU times: user 25.8 s, sys: 30.8 ms, total: 25.9 s
#Wall time: 26.1 s
```

Running with parallel support:
```python
%%time
v = p.calculate_map({'src.T':times, '_':np.arange(10)},
                    output='reshape', map_function='ProcessPool')
#CPU times: user 828 ms, sys: 99.1 ms, total: 927 ms
#Wall time: 7.42 s
```